### PR TITLE
Say radio: Omit announce if selected station title starts with the identical announce text

### DIFF
--- a/webfrontend/html/Radio.php
+++ b/webfrontend/html/Radio.php
@@ -216,7 +216,13 @@ function say_radio_station() {
 	$play_stat = $TL['SONOS-TO-SPEECH']['ANNOUNCE_RADIO'] ; 
 	#********************************************************************
 	# Generiert und kodiert Ansage des laufenden Senders
-	$text = ($play_stat.' '.$temp_radio['title']);
+	if (strncmp($temp_radio['title'], $play_stat, strlen($play_stat))===0) {
+    	# Nur Titel des Senders ansagen, falls Titel mit dem Announce-Radio Text übereinstimmt
+	    $text = $temp_radio['title'];
+	} else {
+	    # Ansage von 'Radio' gefolgt vom Titel des Senders
+	    $text = ($play_stat.' '.$temp_radio['title']);
+	}
 	$textstring = ($text);
 	$rawtext = md5($textstring);
 	$filename = "$rawtext";


### PR DESCRIPTION
If selected radio station titel starts with the configured announce radio prefix, the prefix is omited when preparing the T2S text.

E.g. "Radio Hit One" is announced as "Radio Hit One" and not as "Radio Radio Hit One"