### PR TITLE
Say radio station for groups

### DIFF
--- a/webfrontend/html/Play_T2S.php
+++ b/webfrontend/html/Play_T2S.php
@@ -250,7 +250,7 @@ function play_tts($filename) {
 			$message_pos = count($sonos->GetCurrentPlaylist()) + 1;
 		} else {
 			// No Playlist is playing
-			$message_pos = count($save_plist);
+			$message_pos = 1;
 		}
 			
 		// Playgong/jingle to be played upfront

--- a/webfrontend/html/Radio.php
+++ b/webfrontend/html/Radio.php
@@ -120,11 +120,7 @@ function nextradio() {
 	LOGGING('Next Radio Info: '.($info_r),7);
     if ($config['VARIOUS']['announceradio'] == 1) {
 		$check_stat = getZoneStatus($master);
-		if ($check_stat == "single")  {
-			say_radio_station();
-		} else {
-			LOGGING("Radio Station could not be announced because Master is grouped",6);
-		}
+		say_radio_station();
 	}
 	$coord = getRoomCoordinator($master);
 	$sonos = new PHPSonos($coord[0]);
@@ -197,7 +193,7 @@ function random_radio() {
 function say_radio_station() {
 			
 	# nach nextradio();
-	global $master, $sonoszone, $config, $min_vol, $volume, $actual, $sonos, $coord, $messageid, $filename, $MessageStorepath, $nextZoneKey;
+	global $master, $sonoszone, $config, $min_vol, $volume, $actual, $sonos, $coord, $messageid, $filename, $MessageStorepath, $nextZoneKey, $member;
 	require_once("addon/sonos-to-speech.php");
 	
 	// if batch has been choosed abort
@@ -227,7 +223,15 @@ function say_radio_station() {
 	$volume = $volume + $config['TTS']['correction'];
 	LOGGING("Radio Station Announcement has been announced", 6);		
 	play_tts($filename);
-	restoreSingleZone();
+	if(isset($_GET['member'])) {
+	    // TODO should this be loaded by a helper function? or already be loaded before calling say_radio_station() 
+	    // Or should say_radio_station() use sendgroupmessage() to play T2S if zones are grouped?
+	    $member = $_GET['member'];
+	    $member = explode(',', $member);
+	    restoreGroupZone();
+	} else {
+	    restoreSingleZone();
+	}
 	if(isset($_GET['volume'])) {
 		$volume = $_GET['volume'];
 	} elseif (isset($_GET['keepvolume'])) {


### PR DESCRIPTION
Added support for groups in say_radio_station()

Open issue to review: 
- $member seems not to be set when say_radio_station() is called.
- Where should this variable be set?
- Or would it be better to use sendgroupmessage() to play T2S message for groups (which would handle and call restoreGroupZone() correctly)

Further: Fixed warning in play_tts() if playlist is empty when calling function.