### PR TITLE
WIP audioClip support

### DIFF
--- a/webfrontend/html/Sonos.php
+++ b/webfrontend/html/Sonos.php
@@ -174,7 +174,7 @@ if ((isset($_GET['text'])) or (isset($_GET['messageid'])) or
 
 	# check if any Favorite function has been executed, if not delete files
 	if (($_GET['action'] == "playallfavorites") || ($_GET['action'] == "playtrackfavorites") || ($_GET['action'] == "playtuneinfavorites")
-		|| ($_GET['action'] == "playradiofavorites") || ($_GET['action'] == "playsonosplaylist") || ($_GET['action'] == "say") || ($_GET['action'] == "playfavorite")
+		|| ($_GET['action'] == "playradiofavorites") || ($_GET['action'] == "playsonosplaylist")|| ($_GET['action'] == "audioclip") || ($_GET['action'] == "say") || ($_GET['action'] == "playfavorite")
 		|| ($_GET['action'] == "play") || ($_GET['action'] == "stop") || ($_GET['action'] == "toggle") || ($_GET['action'] == "playplfavorites")
 		|| ($_GET['action'] == "next") || ($_GET['action'] == "previous") || ($_GET['action'] == "volume") || ($_GET['action'] == "pause") || ($_GET['action'] == "zapzone")
 		|| (isset($_GET['volume']) === true) || ($_GET['action'] == "sendmessage") || ($_GET['action'] == "sonosplaylist") || ($_GET['action'] == "sendgroupmessage")
@@ -881,6 +881,11 @@ if(array_key_exists($_GET['zone'], $sonoszone)){
 			} else {
 				LOGGING("sonos.php: Same text has been announced within the last ".$min_sec." seconds. We skip this anouncement", 5); 
 			}
+		break;
+
+		case 'audioclip':
+			LOGDEB("sonos.php: audioclip called");
+			playAudioclip();
 		break;
 		
 				


### PR DESCRIPTION
Proper integration is needed (local/remote URLS, multiple/all players (synchronised?)).

- cleanup (what to do with the GUID, just take a static one?), php documentation
- Check if all current (old) devices are supported:

Old documentation:
https://web.archive.org/web/20230330171701/https://developer.sonos.com/reference/control-api/audioclip/

This namespace is experimental. Some of the functionality may not yet work as documented. Sonos supports audio clips on new players and players that have a microphone. This includes Sonos One, Amp, Port, Play:5 (gen 2), Beam, One SL, Move, as well as the SYMFONISK table lamp with WiFi and SYMFONISK WiFi bookshelf speakers.

if not:

To check whether a player supports this API, we could perform once (when scanning the player? But then you need to re-scan when you want to use the new audioClip API), this call:

```
curl -v --insecure \
  -H 'X-Sonos-Api-Key:123e4567-e89b-12d3-a456-426655440000' \
  https://192.168.1.40:1443/api/v1/players/local/info
```
It responds with containing this JSON entry:
`"capabilities":["CLOUD","PLAYBACK","AIRPLAY","VOICE","AUDIO_CLIP"]` where we can check whether AUDIO_CLIP is supported...
